### PR TITLE
Fix for BaseApiClient import

### DIFF
--- a/src/etsy3py/v3.py
+++ b/src/etsy3py/v3.py
@@ -2,7 +2,7 @@ from typing import Optional, List
 
 import requests
 
-from src.etsy3py.base_client import BaseApiClient
+from etsy3py.base_client import BaseApiClient
 
 
 class EtsyApi(BaseApiClient):


### PR DESCRIPTION
Hi,

this is a fix for this issue I've opened : 

[Issue 6](https://github.com/damhuman/Etsy3Py/issues/6)

It's fixing the bad import I have when I use your library and try to call the **EtsyApi** function.